### PR TITLE
Update 0.5.2.9

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@ bl_info = {
     'author': 'bonjorno7, Gorange, RED_EYE, SethTooQuick, Cabbage McGravel, Almaas',
     'description': 'A more convenient alternative to Blender Source Tools',
     'blender': (2, 80, 0),
-    'version': (0, 5, 2, 8),
+    'version': (0, 5, 2, 9),
     'location': '3D View > Sidebar',
     'category': 'Import-Export'
 }

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -64,12 +64,6 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         default=False,
     )
 
-    blank: bpy.props.BoolProperty(
-        name='Blank Bodygroup',
-        description='Whether to add a blank bodygroup, if bodygroups are used',
-        default=False,
-    )
-
     prepend_armature: bpy.props.BoolProperty(
         name='Prepend Armature',
         description='Prepend the name of the armature to every bone name in your SMD files. Necessary for multi-armature models',

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -67,7 +67,7 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
     prepend_armature: bpy.props.BoolProperty(
         name='Prepend Armature',
         description='Prepend the name of the armature to every bone name in your SMD files. Necessary for multi-armature models',
-        default=True,
+        default=False,
     )
 
     ignore_transforms: bpy.props.BoolProperty(

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -58,6 +58,12 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         default=False,
     )
 
+    static_prop_combine: bpy.props.BoolProperty(
+        name='Static Prop Combine',
+        description='Whether to use the steamapps/content path instead of modelsrc, necessary for autocombine, a neat CS:GO feature',
+        default=False,
+    )
+
     glass: bpy.props.BoolProperty(
         name='Has Glass',
         description='$mostlyopaque, use this if your model has something transparent like glass',

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -10,13 +10,19 @@ class Model:
     def __init__(self, game, model):
         self.game = Path(game.game)
         self.bin = Path(game.bin)
-        self.modelsrc = Path(game.modelsrc)
+        if model.static and model.static_prop_combine:
+            self.modelsrc = self.game.parent.parent.joinpath('content', self.game.name, 'models')
+        else:
+            self.modelsrc = Path(game.modelsrc)
         self.models = Path(game.models)
         self.mapsrc = Path(game.mapsrc)
 
         self.name = str(Path(model.name).with_suffix(''))
         self.basename = common.clean_filename(Path(self.name).stem)
-        directory = self.modelsrc.joinpath(self.name)
+        if model.static and model.static_prop_combine:
+            directory = self.modelsrc.joinpath(Path(self.name).parent)
+        else:
+            directory = self.modelsrc.joinpath(self.name)
         self.directory = common.verify_folder(directory)
 
         studiomdl = self.bin.joinpath('studiomdl.exe')

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -36,7 +36,6 @@ class Model:
         self.surface = model.surface
         self.static = model.static
         self.glass = model.glass
-        self.blank = model.blank
 
         self.prepend_armature = model.prepend_armature
         self.ignore_transforms = model.ignore_transforms
@@ -178,8 +177,6 @@ class Model:
                 for collection in bodygroup.children:
                     name = common.clean_filename(collection.name)
                     qc.write(f'    studio "{name}.smd"\n')
-                if self.blank:
-                    qc.write('    blank\n')
                 qc.write('}')
                 qc.write('\n')
 

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -81,7 +81,6 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             col.prop(model, 'surface')
             col.prop(model, 'static')
             col.prop(model, 'glass')
-            col.prop(model, 'blank')
 
             box = layout.box()
             row = box.row()

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -80,6 +80,9 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             col = common.split_column(box)
             col.prop(model, 'surface')
             col.prop(model, 'static')
+            row = col.row()
+            row.enabled = model.static
+            row.prop(model, 'static_prop_combine')
             col.prop(model, 'glass')
 
             box = layout.box()

--- a/addon/utils/common.py
+++ b/addon/utils/common.py
@@ -115,3 +115,8 @@ def documents():
 
     else:
         return pathlib.Path.home()
+
+
+def appdata():
+    user = bpy.utils.resource_path('USER')
+    return pathlib.Path(user).resolve()


### PR DESCRIPTION
Changes in this update:
- Removed the blank bodygroup option, as you can just add an empty collection to get the same result
- Make the prepend armature option disabled by default, because it seems that's usually what people want
- Add support for static prop combine (csgo only)