### PR TITLE
Add "Attachments" support

### DIFF
--- a/addon/ops/list_operator.py
+++ b/addon/ops/list_operator.py
@@ -41,6 +41,7 @@ class SOURCEOPS_OT_ListOperator(bpy.types.Operator):
             ('SEQUENCES', 'Sequences', 'Operate on sequences'),
             ('EVENTS', 'Events', 'Operate on events'),
             ('MAPS', 'Maps', 'Operate on maps'),
+            ('ATTACHMENTS', 'Attachments', 'Operate on attachments')
         ],
     )
 
@@ -101,6 +102,7 @@ class SOURCEOPS_OT_ListOperator(bpy.types.Operator):
             'SEQUENCES': (model, 'sequence_items', 'sequence_index'),
             'EVENTS': (sequence, 'event_items', 'event_index'),
             'MAPS': (sourceops, 'map_items', 'map_index'),
+            'ATTACHMENTS': (model, 'attachment_items', 'attachment_index')
         }
 
         function = mode_dict[self.mode]

--- a/addon/props/__init__.py
+++ b/addon/props/__init__.py
@@ -2,6 +2,7 @@ import bpy
 from . map_props import SOURCEOPS_MapProps
 from . event_props import SOURCEOPS_EventProps
 from . sequence_props import SOURCEOPS_SequenceProps
+from . attachment_props import SOURCEOPS_AttachmentProps
 from . skin_props import SOURCEOPS_SkinProps
 from . material_folder_props import SOURCEOPS_MaterialFolderProps
 from . model_props import SOURCEOPS_ModelProps
@@ -14,6 +15,7 @@ def register():
     bpy.utils.register_class(SOURCEOPS_MapProps)
     bpy.utils.register_class(SOURCEOPS_EventProps)
     bpy.utils.register_class(SOURCEOPS_SequenceProps)
+    bpy.utils.register_class(SOURCEOPS_AttachmentProps)
     bpy.utils.register_class(SOURCEOPS_SkinProps)
     bpy.utils.register_class(SOURCEOPS_MaterialFolderProps)
     bpy.utils.register_class(SOURCEOPS_ModelProps)
@@ -32,5 +34,6 @@ def unregister():
     bpy.utils.unregister_class(SOURCEOPS_MaterialFolderProps)
     bpy.utils.unregister_class(SOURCEOPS_SkinProps)
     bpy.utils.unregister_class(SOURCEOPS_SequenceProps)
+    bpy.utils.unregister_class(SOURCEOPS_AttachmentProps)
     bpy.utils.unregister_class(SOURCEOPS_EventProps)
     bpy.utils.unregister_class(SOURCEOPS_MapProps)

--- a/addon/props/attachment_props.py
+++ b/addon/props/attachment_props.py
@@ -1,0 +1,41 @@
+import bpy
+
+
+class SOURCEOPS_AttachmentProps(bpy.types.PropertyGroup):
+    name: bpy.props.StringProperty(
+        name='Name',
+        description='The name of this attachment.',
+        default='Implicit',
+    )
+
+    boneName: bpy.props.StringProperty(
+        name='Bone Name',
+        description='The name of the bone that this attachment should attach to. Name should be formatted as "<ARMATURENAME>.<BONENAME>".',
+        default='Source.Implicit',
+    )
+
+    offset: bpy.props.FloatVectorProperty(
+        name='Offset',
+        subtype="XYZ",
+        description='The local X, Y, and Z position of the attachment (relative to the bone position).',
+        default=[0.0, 0.0, 0.0],
+    )
+
+    absolute: bpy.props.BoolProperty(
+        name='Absolute',
+        description='Parented to the model\'s origin. The offset is still relative to the given parent bone, however!',
+        default=False,
+    )
+
+    rigid: bpy.props.BoolProperty(
+        name='Rigid',
+        description='Declares that the bone this attachment is parented to will not move, allowing Studiomdl to optimise it out. Used to convert bones created in a modelling package into attachments.',
+        default=False,
+    )
+
+    rotationPYR: bpy.props.FloatVectorProperty(
+        name='Rotation (Pitch, Yaw, Roll)',
+        subtype="EULER",
+        description='Rotates the attachment, in degrees, relative to its parent bone / the origin. Formatted as [pitch, yaw, roll].',
+        default=[0.0, 0.0, 0.0],
+    )

--- a/addon/props/global_props.py
+++ b/addon/props/global_props.py
@@ -34,5 +34,6 @@ class SOURCEOPS_GlobalProps(bpy.types.PropertyGroup):
             ('EVENTS', 'Events', 'Display the events panel', 'ACTION', 6),
             ('MAPS', 'Maps', 'Display the maps panel', 'MOD_BUILD', 7),
             ('SIMULATION', 'Simulation', 'Display the simulation panel', 'PHYSICS', 8),
+            ('ATTACHMENTS', 'Attachments', 'Display the attachments panel', 'BONE_DATA', 9)
         ],
     )

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -2,6 +2,7 @@ import bpy
 from . material_folder_props import SOURCEOPS_MaterialFolderProps
 from . skin_props import SOURCEOPS_SkinProps
 from . sequence_props import SOURCEOPS_SequenceProps
+from . attachment_props import SOURCEOPS_AttachmentProps
 from . surface_props import SOURCEOPS_SurfaceProps
 
 
@@ -14,6 +15,9 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
 
     sequence_items: bpy.props.CollectionProperty(type=SOURCEOPS_SequenceProps)
     sequence_index: bpy.props.IntProperty(default=0, name='Ctrl click to rename')
+
+    attachment_items: bpy.props.CollectionProperty(type=SOURCEOPS_AttachmentProps)
+    attachment_index: bpy.props.IntProperty(default=0, name='Ctrl click to rename')
 
     name: bpy.props.StringProperty(
         name='Name',

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -33,6 +33,7 @@ class Model:
         self.material_folder_items = model.material_folder_items
         self.skin_items = model.skin_items
         self.sequence_items = model.sequence_items
+        self.attachment_items = model.attachment_items
 
         self.reference = model.reference
         self.collision = model.collision
@@ -217,6 +218,16 @@ class Model:
             for event in sequence.event_items:
                 qc.write('    { ' + f'event "{event.event}" {event.frame} "{event.value}"' + ' }\n')
             qc.write('}')
+            qc.write('\n')
+
+        qc.write('\n')
+        for attachment in self.attachment_items:
+            qc.write(f'$attachment "{attachment.name}" "{attachment.boneName}" {attachment.offset[0]} {attachment.offset[1]} {attachment.offset[2]} ')
+            if attachment.absolute:
+                qc.write('absolute ')
+            if attachment.rigid:
+                qc.write('rigid ')
+            qc.write(f'rotate {attachment.rotationPYR[0]} {attachment.rotationPYR[1]} {attachment.rotationPYR[2]}\n')
             qc.write('\n')
 
         if self.skin_items:

--- a/addon/ui/__init__.py
+++ b/addon/ui/__init__.py
@@ -4,6 +4,7 @@ from . lists import SOURCEOPS_UL_ModelList
 from . lists import SOURCEOPS_UL_MaterialFolderList
 from . lists import SOURCEOPS_UL_SkinList
 from . lists import SOURCEOPS_UL_SequenceList
+from . lists import SOURCEOPS_UL_AttachmentList
 from . lists import SOURCEOPS_UL_EventList
 from . lists import SOURCEOPS_UL_MapList
 from . panels import SOURCEOPS_PT_MainPanel
@@ -15,6 +16,7 @@ def register():
     bpy.utils.register_class(SOURCEOPS_UL_MaterialFolderList)
     bpy.utils.register_class(SOURCEOPS_UL_SkinList)
     bpy.utils.register_class(SOURCEOPS_UL_SequenceList)
+    bpy.utils.register_class(SOURCEOPS_UL_AttachmentList)
     bpy.utils.register_class(SOURCEOPS_UL_EventList)
     bpy.utils.register_class(SOURCEOPS_UL_MapList)
     bpy.utils.register_class(SOURCEOPS_PT_MainPanel)
@@ -25,6 +27,7 @@ def unregister():
     bpy.utils.unregister_class(SOURCEOPS_UL_MapList)
     bpy.utils.unregister_class(SOURCEOPS_UL_EventList)
     bpy.utils.unregister_class(SOURCEOPS_UL_SequenceList)
+    bpy.utils.unregister_class(SOURCEOPS_UL_AttachmentList)
     bpy.utils.unregister_class(SOURCEOPS_UL_SkinList)
     bpy.utils.unregister_class(SOURCEOPS_UL_MaterialFolderList)
     bpy.utils.unregister_class(SOURCEOPS_UL_ModelList)

--- a/addon/ui/lists.py
+++ b/addon/ui/lists.py
@@ -36,6 +36,13 @@ class SOURCEOPS_UL_SequenceList(bpy.types.UIList):
         layout.prop(item, 'name', text='', emboss=False, translate=False)
 
 
+class SOURCEOPS_UL_AttachmentList(bpy.types.UIList):
+    bl_idname = 'SOURCEOPS_UL_AttachmentList'
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
+        layout.prop(item, 'name', text='', emboss=False, translate=False)
+
+
 class SOURCEOPS_UL_EventList(bpy.types.UIList):
     bl_idname = 'SOURCEOPS_UL_EventList'
 

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -20,6 +20,7 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
         material_folder = common.get_material_folder(model)
         skin = common.get_skin(model)
         sequence = common.get_sequence(model)
+        attachment = common.get_attachment(model)
         event = common.get_event(sequence)
         map_props = common.get_map(sourceops)
 
@@ -175,7 +176,27 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
                 col.prop(event, 'frame')
                 col.prop(event, 'value')
 
-        if sourceops.panel in {'GAMES', 'MODELS', 'MODEL_OPTIONS', 'TEXTURES', 'SEQUENCES', 'EVENTS'}:
+        elif sourceops.panel == 'ATTACHMENTS' and model:
+            box = layout.box()
+            row = box.row()
+            row.alignment = 'CENTER'
+            row.label(text='Attachments')
+
+            row = box.row()
+            row.template_list('SOURCEOPS_UL_AttachmentList', '', model, 'attachment_items', model, 'attachment_index', rows=5)
+            col = row.column(align=True)
+            self.draw_list_buttons(col, 'ATTACHMENTS')
+
+            if attachment:
+                col = common.split_column(box)
+                col.prop(attachment, 'name')
+                col.prop(attachment, 'boneName')
+                col.prop(attachment, 'offset')
+                col.prop(attachment, 'absolute')
+                col.prop(attachment, 'rigid')
+                col.prop(attachment, 'rotationPYR')
+
+        if sourceops.panel in {'GAMES', 'MODELS', 'MODEL_OPTIONS', 'TEXTURES', 'SEQUENCES', 'EVENTS', 'ATTACHMENTS'}:
             box = layout.box()
             row = box.row()
             row.scale_x = row.scale_y = 1.5

--- a/addon/utils/common.py
+++ b/addon/utils/common.py
@@ -59,6 +59,13 @@ def get_sequence(model):
         return None
 
 
+def get_attachment(model):
+    try:
+        return model.attachment_items[model.attachment_index]
+    except:
+        return None
+
+
 def get_event(sequence):
     try:
         return sequence.event_items[sequence.event_index]


### PR DESCRIPTION
This adds an "Attachment" panel to SourceOps. 

Resolves #55

![SourceOps_Attachments](https://user-images.githubusercontent.com/28817202/105219764-d545be00-5b24-11eb-866a-4da7a88487d3.png)
