### PR TITLE
Update to attachments panel; armature/bone search instead of manual string input

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@ bl_info = {
     'author': 'bonjorno7, Gorange, RED_EYE, SethTooQuick, Cabbage McGravel, Almaas',
     'description': 'A more convenient alternative to Blender Source Tools',
     'blender': (2, 80, 0),
-    'version': (0, 5, 3, 0),
+    'version': (0, 5, 3, 1),
     'location': '3D View > Sidebar',
     'category': 'Import-Export'
 }

--- a/addon/props/attachment_props.py
+++ b/addon/props/attachment_props.py
@@ -10,13 +10,13 @@ class SOURCEOPS_AttachmentProps(bpy.types.PropertyGroup):
 
     armature: bpy.props.StringProperty(
         name='Armature',
-        description='The armature to choose the bone from."',
+        description='The armature to choose the bone from',
         default='',
     )
 
     bone: bpy.props.StringProperty(
         name='Bone',
-        description='The bone that this attachment should attach to."',
+        description='The bone that this attachment should attach to',
         default='',
     )
 

--- a/addon/props/attachment_props.py
+++ b/addon/props/attachment_props.py
@@ -8,10 +8,16 @@ class SOURCEOPS_AttachmentProps(bpy.types.PropertyGroup):
         default='Attachment',
     )
 
+    armature: bpy.props.StringProperty(
+        name='Armature',
+        description='The armature to choose the bone from."',
+        default='',
+    )
+
     bone: bpy.props.StringProperty(
-        name='Bone Name',
-        description='The name of the bone that this attachment should attach to. If using Prepend Armature, name should be formatted as "<Armature>.<Bone>"',
-        default='Bone',
+        name='Bone',
+        description='The bone that this attachment should attach to."',
+        default='',
     )
 
     offset: bpy.props.FloatVectorProperty(

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -221,12 +221,13 @@ class Model:
             qc.write('\n')
 
         for attachment in self.attachment_items:
-            if (attachment.armature and attachment.bone):
+            if attachment.armature and attachment.bone:
                 qc.write('\n')
-                qc.write(f'$attachment "{attachment.name}" "')
-                if (self.prepend_armature):
-                    qc.write(f'{attachment.armature}.')
-                qc.write(f'{attachment.bone}"')
+                qc.write(f'$attachment "{attachment.name}"')
+                if self.prepend_armature:
+                    qc.write(f' "{attachment.armature}.{attachment.bone}"')
+                else:
+                    qc.write(f' "{attachment.bone}"')
                 qc.write(f' {attachment.offset[0]} {attachment.offset[1]} {attachment.offset[2]}')
                 if attachment.absolute:
                     qc.write(' absolute')

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -221,19 +221,19 @@ class Model:
             qc.write('\n')
 
         for attachment in self.attachment_items:
-            qc.write('\n')
-            qc.write(f'$attachment "{attachment.name}"')
-            if (not attachment.armature or not self.prepend_armature):
-                qc.write(f' "{attachment.bone}"')
-            else:
-                qc.write(f' "{attachment.armature}.{attachment.bone}"')
-            qc.write(f' {attachment.offset[0]} {attachment.offset[1]} {attachment.offset[2]}')
-            if attachment.absolute:
-                qc.write(' absolute')
-            if attachment.rigid:
-                qc.write(' rigid')
-            qc.write(f' rotate {attachment.rotation[0]} {attachment.rotation[1]} {attachment.rotation[2]}')
-            qc.write('\n')
+            if (attachment.armature and attachment.bone):
+                qc.write('\n')
+                qc.write(f'$attachment "{attachment.name}" "')
+                if (self.prepend_armature):
+                    qc.write(f'{attachment.armature}.')
+                qc.write(f'{attachment.bone}"')
+                qc.write(f' {attachment.offset[0]} {attachment.offset[1]} {attachment.offset[2]}')
+                if attachment.absolute:
+                    qc.write(' absolute')
+                if attachment.rigid:
+                    qc.write(' rigid')
+                qc.write(f' rotate {attachment.rotation[0]} {attachment.rotation[1]} {attachment.rotation[2]}')
+                qc.write('\n')
 
         if self.skin_items:
             qc.write('\n')

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -222,7 +222,11 @@ class Model:
 
         for attachment in self.attachment_items:
             qc.write('\n')
-            qc.write(f'$attachment "{attachment.name}" "{attachment.bone}"')
+            qc.write(f'$attachment "{attachment.name}"')
+            if (not attachment.armature or not self.prepend_armature):
+                qc.write(f' "{attachment.bone}"')
+            else:
+                qc.write(f' "{attachment.armature}.{attachment.bone}"')
             qc.write(f' {attachment.offset[0]} {attachment.offset[1]} {attachment.offset[2]}')
             if attachment.absolute:
                 qc.write(' absolute')

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -190,10 +190,12 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             if attachment:
                 col = common.split_column(box)
                 col.prop(attachment, 'name')
-                col.prop_search(attachment, "armature", bpy.data, "armatures")
+
+                col.prop_search(attachment, 'armature', bpy.data, 'armatures')
                 armature = bpy.data.armatures.get(attachment.armature)
-                if armature is not None:
-                    col.prop_search(attachment, "bone", armature, "bones")
+                if armature:
+                    col.prop_search(attachment, 'bone', armature, 'bones')
+
                 col.prop(attachment, 'offset')
                 col.prop(attachment, 'rotation')
                 col.prop(attachment, 'absolute')

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -190,7 +190,10 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             if attachment:
                 col = common.split_column(box)
                 col.prop(attachment, 'name')
-                col.prop(attachment, 'bone')
+                col.prop_search(attachment, "armature", bpy.data, "armatures")
+                armature = bpy.data.armatures.get(attachment.armature)
+                if armature is not None:
+                    col.prop_search(attachment, "bone", armature, "bones")
                 col.prop(attachment, 'offset')
                 col.prop(attachment, 'rotation')
                 col.prop(attachment, 'absolute')


### PR DESCRIPTION
A small update to the attachments panel. This adds a prop_search UI element for the bone name entry, instead of the previous manual bone name string input. Searching for bones requires an armature to search for bones in, so another prop_search for choosing the armature to search bones from is added too.

![SourceOps_Attachments_2](https://user-images.githubusercontent.com/28817202/105257744-6aad7600-5b56-11eb-82d9-28544c771872.png)