### PR TITLE
Add functionality to use a custom object as the origin (and scale, etc)

### DIFF
--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -90,14 +90,14 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         name='Transform Source',
         description='Method of specifying $origin and $scale.\nEither manually specified in this panel, or via an object',
         items=[
-            ('MANUAL', 'Manual Input', 'Specify the Transform manually in this panel'),
-            ('OBJECT', 'Object', 'Use an Object\'s transforms\nIf it is None, then falls back to Manual Input')
-        ]
+            ('MANUAL', 'Manual Input', 'Specify the transforms manually in this panel'),
+            ('OBJECT', 'Object', 'Use an Object\'s transforms\nIf it is None, then no transforms are used'),
+        ],
     )
 
     transform_object: bpy.props.PointerProperty(
         name='Transform Object',
-        description='The object to use the transform of as the $origin, $scale and Z-Axis rotation',
+        description='The object to use the transforms of as the $origin and $scale',
         type=bpy.types.Object,
     )
 

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -91,7 +91,7 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         description='Method of specifying $origin and $scale.\nEither manually specified in this panel, or via an object',
         items=[
             ('MANUAL', 'Manual Input', 'Specify the transforms manually in this panel'),
-            ('OBJECT', 'Object', 'Use an Object\'s transforms\nIf it is None, then no transforms are used'),
+            ('OBJECT', 'Object', 'Use an object\'s transforms\nIf it is None, then no transforms are used'),
         ],
     )
 

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -86,18 +86,18 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         default=False,
     )
 
-    custom_transform_source: bpy.props.EnumProperty(
+    transform_source: bpy.props.EnumProperty(
         name='Transform Source',
-        description='Method of specifying $origin and $scale\nEither manually specified in this Panel, or via an object',
+        description='Method of specifying $origin and $scale.\nEither manually specified in this panel, or via an object',
         items=[
-            ('MANUAL', 'Manual Input', 'Specify the Transform manually in this panel', 'NONE', 1),
-            ('CUSTOM_OBJECT', 'Object', 'Use an Object\'s transforms\nIf it is None, then falls back to Manual Input', 'NONE', 2)
+            ('MANUAL', 'Manual Input', 'Specify the Transform manually in this panel'),
+            ('OBJECT', 'Object', 'Use an Object\'s transforms\nIf it is None, then falls back to Manual Input')
         ]
     )
 
-    custom_transform_object_ref: bpy.props.PointerProperty(
+    transform_object: bpy.props.PointerProperty(
         name='Transform Object',
-        description='The Object to use the transform of as the $origin and $scale',
+        description='The object to use the transform of as the $origin, $scale and Z-Axis rotation',
         type=bpy.types.Object,
     )
 

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -88,13 +88,13 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
 
     use_other_object_origin: bpy.props.BoolProperty(
         name='Use Other Object\'s Origin',
-        description='Use the position of another object as the $origin',
+        description='Use the position of another object as the $origin and $scale',
         default=False,
     )
 
     other_object_ref: bpy.props.PointerProperty(
         name='Other Object',
-        description='The other Object to use the position of as the $origin',
+        description='The other Object to use the position of as the $origin and $scale',
         type=bpy.types.Object,
     )
 

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -86,15 +86,18 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         default=False,
     )
 
-    use_other_object_origin: bpy.props.BoolProperty(
-        name='Use Other Object\'s Origin',
-        description='Use the position of another object as the $origin and $scale',
-        default=False,
+    custom_transform_source: bpy.props.EnumProperty(
+        name='Transform Source',
+        description='Method of specifying $origin and $scale\nEither manually specified in this Panel, or via an object',
+        items=[
+            ('MANUAL', 'Manual Input', 'Specify the Transform manually in this panel', 'NONE', 1),
+            ('CUSTOM_OBJECT', 'Object', 'Use an Object\'s transforms\nIf it is None, then falls back to Manual Input', 'NONE', 2)
+        ]
     )
 
-    other_object_ref: bpy.props.PointerProperty(
-        name='Other Object',
-        description='The other Object to use the position of as the $origin and $scale',
+    custom_transform_object_ref: bpy.props.PointerProperty(
+        name='Transform Object',
+        description='The Object to use the transform of as the $origin and $scale',
         type=bpy.types.Object,
     )
 

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -86,6 +86,18 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         default=False,
     )
 
+    use_other_object_origin: bpy.props.BoolProperty(
+        name='Use Other Object\'s Origin',
+        description='Use the position of another object as the $origin',
+        default=False,
+    )
+
+    other_object_ref: bpy.props.PointerProperty(
+        name='Other Object',
+        description='The other Object to use the position of as the $origin',
+        type=bpy.types.Object,
+    )
+
     origin_x: bpy.props.FloatProperty(
         name='Origin +X',
         description='Translation on the positive X axis for $origin in the QC file',

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -91,7 +91,7 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         description='Method of specifying $origin and $scale.\nEither manually specified in this panel, or via an object',
         items=[
             ('MANUAL', 'Manual Input', 'Specify the transforms manually in this panel'),
-            ('OBJECT', 'Object', 'Use an object\'s transforms\nIf it is None, then no transforms are used'),
+            ('OBJECT', 'Object', 'Use an object\'s transforms\nIf it isn\'t set, then no transforms are used'),
         ],
     )
 

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -49,6 +49,10 @@ class Model:
 
         self.prepend_armature = model.prepend_armature
         self.ignore_transforms = model.ignore_transforms
+
+        self.use_other_object_origin = model.use_other_object_origin
+        self.other_object_ref = model.other_object_ref
+
         self.origin_x = model.origin_x
         self.origin_y = model.origin_y
         self.origin_z = model.origin_z
@@ -172,13 +176,29 @@ class Model:
             qc.write('$mostlyopaque')
             qc.write('\n')
 
-        qc.write('\n')
-        qc.write(f'$origin {self.origin_x} {self.origin_y} {self.origin_z} {self.rotation}')
-        qc.write('\n')
+        if not self.use_other_object_origin:
+            qc.write('\n')
+            qc.write(f'$origin {self.origin_x} {self.origin_y} {self.origin_z} {self.rotation}')
+            qc.write('\n')
 
-        qc.write('\n')
-        qc.write(f'$scale {self.scale}')
-        qc.write('\n')
+            qc.write('\n')
+            qc.write(f'$scale {self.scale}')
+            qc.write('\n')
+        else:
+            # Using temp variables for readability
+            ref_obj_pos_x = self.other_object_ref.matrix_world[0][3]
+            ref_obj_pos_y = self.other_object_ref.matrix_world[1][3]
+            ref_obj_pos_z = self.other_object_ref.matrix_world[2][3]
+            ref_obj_scale = self.other_object_ref.matrix_world[0][0]
+
+            qc.write('\n')
+            qc.write(f'$origin {ref_obj_pos_x} {ref_obj_pos_y} {ref_obj_pos_z} {self.rotation}')
+            qc.write('\n')
+
+            qc.write('\n')
+            # Using only the X scale at this time, assumes the object used is uniform scale
+            qc.write(f'$scale {ref_obj_scale}')
+            qc.write('\n')
 
         if self.reference:
             qc.write('\n')

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -177,40 +177,35 @@ class Model:
             qc.write('$mostlyopaque')
             qc.write('\n')
 
+        output_x = 0
+        output_y = 0
+        output_z = 0
+        output_rotation = 0
+        output_scale = 1
+
         if self.custom_transform_source == 'MANUAL':
-            qc.write('\n')
-            qc.write(f'$origin {self.origin_x} {self.origin_y} {self.origin_z} {self.rotation}')
-            qc.write('\n')
-
-            qc.write('\n')
-            qc.write(f'$scale {self.scale}')
-            qc.write('\n')
+            output_x = self.origin_x
+            output_y = self.origin_y
+            output_z = self.origin_z
+            output_rotation = self.rotation
+            output_scale = self.scale
         elif self.custom_transform_source == 'CUSTOM_OBJECT' and self.custom_transform_object_ref is not None:
-            # Using temp variables for readability
-            ref_obj_pos_x = self.custom_transform_object_ref.matrix_world[0][3]
-            ref_obj_pos_y = self.custom_transform_object_ref.matrix_world[1][3]
-            ref_obj_pos_z = self.custom_transform_object_ref.matrix_world[2][3]
-            ref_obj_rot_z = degrees(self.custom_transform_object_ref.rotation_euler.z)
+            output_x = self.custom_transform_object_ref.matrix_world[0][3]
+            output_y = self.custom_transform_object_ref.matrix_world[1][3]
+            output_z = self.custom_transform_object_ref.matrix_world[2][3]
+            output_rotation = degrees(self.custom_transform_object_ref.rotation_euler.z)
             # Only using X axis for scale, as the object is assumed to be uniformly scaled
-            ref_obj_scale = self.custom_transform_object_ref.scale.x
-
-            qc.write('\n')
-            qc.write(f'$origin {ref_obj_pos_x} {ref_obj_pos_y} {ref_obj_pos_z} {ref_obj_rot_z}')
-            qc.write('\n')
-
-            qc.write('\n')
-            qc.write(f'$scale {ref_obj_scale}')
-            qc.write('\n')
+            output_scale = self.custom_transform_object_ref.scale.x
         else:
             print('WARNING: No object was specified for custom transforms! Defaulting.')
 
-            qc.write('\n')
-            qc.write(f'$origin 0 0 0 0')
-            qc.write('\n')
+        qc.write('\n')
+        qc.write(f'$origin {output_x} {output_y} {output_z} {output_rotation}')
+        qc.write('\n')
 
-            qc.write('\n')
-            qc.write(f'$scale 1')
-            qc.write('\n')
+        qc.write('\n')
+        qc.write(f'$scale {output_scale}')
+        qc.write('\n')
                 
 
         if self.reference:

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -184,12 +184,12 @@ class Model:
             rotation = self.rotation
             scale = self.scale
         elif self.transform_source == 'OBJECT' and self.transform_object is not None:
-            matrix = self.transform_object.matrix_world.decompose()
-            origin_x = -matrix[0][0]
-            origin_y = -matrix[0][1]
-            origin_z = -matrix[0][2]
-            rotation = degrees(matrix[1].to_euler('XYZ')[2])
-            scale = matrix[2][2]
+            loc, rot, sca = self.transform_object.matrix_world.decompose()
+            origin_x = -loc.x
+            origin_y = -loc.y
+            origin_z = -loc.z
+            rotation = degrees(rot.to_euler().z)
+            scale = sca.z
         else:
             origin_x = 0
             origin_y = 0
@@ -198,11 +198,11 @@ class Model:
             scale = 1
 
         qc.write('\n')
-        qc.write(f'$origin {origin_x} {origin_y} {origin_z} {rotation}')
+        qc.write(f'$origin {origin_x:.6f} {origin_y:.6f} {origin_z:.6f} {rotation:.6f}')
         qc.write('\n')
 
         qc.write('\n')
-        qc.write(f'$scale {scale}')
+        qc.write(f'$scale {scale:.6f}')
         qc.write('\n')
                 
         if self.reference:

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -177,10 +177,7 @@ class Model:
             qc.write('$mostlyopaque')
             qc.write('\n')
 
-        if self.custom_transform_source == 'MANUAL' or self.custom_transform_object_ref is None:
-            # How to properly report error? Extract to method?
-            if self.custom_transform_object_ref is None:
-                print('No object was specified for custom transforms!\nFalling back to manual input.')
+        if self.custom_transform_source == 'MANUAL':
             qc.write('\n')
             qc.write(f'$origin {self.origin_x} {self.origin_y} {self.origin_z} {self.rotation}')
             qc.write('\n')
@@ -188,7 +185,7 @@ class Model:
             qc.write('\n')
             qc.write(f'$scale {self.scale}')
             qc.write('\n')
-        else:
+        elif self.custom_transform_source == 'CUSTOM_OBJECT' and self.custom_transform_object_ref is not None:
             # Using temp variables for readability
             ref_obj_pos_x = self.custom_transform_object_ref.matrix_world[0][3]
             ref_obj_pos_y = self.custom_transform_object_ref.matrix_world[1][3]
@@ -204,6 +201,17 @@ class Model:
             qc.write('\n')
             qc.write(f'$scale {ref_obj_scale}')
             qc.write('\n')
+        else:
+            print('WARNING: No object was specified for custom transforms! Defaulting.')
+
+            qc.write('\n')
+            qc.write(f'$origin 0 0 0 0')
+            qc.write('\n')
+
+            qc.write('\n')
+            qc.write(f'$scale 1')
+            qc.write('\n')
+                
 
         if self.reference:
             qc.write('\n')

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -190,9 +190,9 @@ class Model:
             output_rotation = self.rotation
             output_scale = self.scale
         elif self.custom_transform_source == 'CUSTOM_OBJECT' and self.custom_transform_object_ref is not None:
-            output_x = self.custom_transform_object_ref.matrix_world[0][3]
+            output_x = (self.custom_transform_object_ref.matrix_world[0][3]) * -1
             output_y = self.custom_transform_object_ref.matrix_world[1][3]
-            output_z = self.custom_transform_object_ref.matrix_world[2][3]
+            output_z = (self.custom_transform_object_ref.matrix_world[2][3]) * -1
             output_rotation = degrees(self.custom_transform_object_ref.rotation_euler.z)
             # Only using X axis for scale, as the object is assumed to be uniformly scaled
             output_scale = self.custom_transform_object_ref.scale.x

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -180,7 +180,7 @@ class Model:
         if self.transform_source == 'MANUAL':
             origin_x = self.origin_x
             origin_y = self.origin_y
-            origin_z = self.origin_z
+            origin_z = -self.origin_z
             rotation = self.rotation
             scale = self.scale
         elif self.transform_source == 'OBJECT' and self.transform_object is not None:

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -95,12 +95,19 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             col = common.split_column(box)
             col.prop(model, 'prepend_armature')
             col.prop(model, 'ignore_transforms')
+            col.prop(model, 'use_other_object_origin')
 
             align = col.column(align=True)
+            align.enabled = not model.use_other_object_origin
             align.prop(model, 'origin_x', text='Origin X')
             align.prop(model, 'origin_y', text='Y')
             align.prop(model, 'origin_z', text='-Z')
+            
+            col = common.split_column(box)
+            col.enabled = model.use_other_object_origin
+            col.prop(model, 'other_object_ref')
 
+            col = common.split_column(box)
             col.prop(model, 'rotation')
             col.prop(model, 'scale')
 

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -95,21 +95,19 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             col = common.split_column(box)
             col.prop(model, 'prepend_armature')
             col.prop(model, 'ignore_transforms')
-            col.prop(model, 'use_other_object_origin')
+            col.prop(model, 'custom_transform_source')
 
-            align = col.column(align=True)
-            align.enabled = not model.use_other_object_origin
-            align.prop(model, 'origin_x', text='Origin X')
-            align.prop(model, 'origin_y', text='Y')
-            align.prop(model, 'origin_z', text='-Z')
-            
-            col = common.split_column(box)
-            col.enabled = model.use_other_object_origin
-            col.prop(model, 'other_object_ref')
+            if model.custom_transform_source == 'CUSTOM_OBJECT':
+                col.prop(model, 'custom_transform_object_ref')
+            else:
+                align = col.column(align=True)
+                align.prop(model, 'origin_x', text='Origin X')
+                align.prop(model, 'origin_y', text='Y')
+                align.prop(model, 'origin_z', text='-Z')
 
-            col = common.split_column(box)
-            col.prop(model, 'rotation')
-            col.prop(model, 'scale')
+                col = common.split_column(box)
+                col.prop(model, 'rotation')
+                col.prop(model, 'scale')
 
         elif model and sourceops.panel == 'TEXTURES':
             box = layout.box()

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -99,6 +99,7 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
 
             if model.transform_source == 'OBJECT':
                 col.prop(model, 'transform_object')
+
             else:
                 align = col.column(align=True)
                 align.prop(model, 'origin_x', text='Origin X')

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -95,10 +95,10 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             col = common.split_column(box)
             col.prop(model, 'prepend_armature')
             col.prop(model, 'ignore_transforms')
-            col.prop(model, 'custom_transform_source')
+            col.prop(model, 'transform_source')
 
-            if model.custom_transform_source == 'CUSTOM_OBJECT':
-                col.prop(model, 'custom_transform_object_ref')
+            if model.transform_source == 'OBJECT':
+                col.prop(model, 'transform_object')
             else:
                 align = col.column(align=True)
                 align.prop(model, 'origin_x', text='Origin X')


### PR DESCRIPTION
Closes #42 
Adds extra option to pick an object from which to specify position, rotation and scale as an input for the `$origin` and `$scale` values in the generated `.qc` file.

If no object is picked whilst using the custom object option, then settings default to 0 0 0 0 for the `$origin`, and 1 for the `$scale`.

Example images:

Old method still supported:
![image](https://user-images.githubusercontent.com/87149601/126244408-b9dee143-bf22-4e35-9800-27ee39541e41.png)

Drop-down:
![image](https://user-images.githubusercontent.com/87149601/126244335-c093dbd1-8ab8-4342-9ab1-74d832d9b110.png)

Picked object:
![image](https://user-images.githubusercontent.com/87149601/126244439-daa3bf5a-9a90-4b8f-b12d-6337c6cc32a5.png)
