### PR TITLE
Use PurePosixPath instead of Path for model name

### DIFF
--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -1,7 +1,7 @@
 import bpy
 import shutil
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from traceback import print_exc
 from ... utils import common
 from . smd import SMD
@@ -20,7 +20,7 @@ class Model:
         self.mapsrc = Path(game.mapsrc)
         self.mesh_type = game.mesh_type
 
-        self.name = str(Path(model.name).with_suffix(''))
+        self.name = str(PurePosixPath(model.name).with_suffix(''))
         self.basename = common.clean_filename(Path(self.name).stem)
         if model.static and model.static_prop_combine:
             directory = self.modelsrc.joinpath(Path(self.name).parent)


### PR DESCRIPTION
Thanks Xbmann for accidentally coming across this error!

This *should* fix the UnicodeDecode exception if the user had `\x` in their model's path.

I don't know if PurePosixPath should be used elsewhere to fix any other backslashes, so I suppose this could be considered a hotfix of sorts.

I'm presuming this is only an issue on Windows since it likes to use backslashes in paths, unsure if functionality is affected on other platforms by this change.

If this fixes the error, then it may be worth considering what other paths should be changed to `PurePosixPath`

Example error given:
![image](https://user-images.githubusercontent.com/87149601/126368976-02420b06-bbdb-4ccd-a3c4-924b167d62fa.png)
