### PR TITLE
Static mesh bodygroup fix and added support for multiple $models in QC

### DIFF
--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -49,6 +49,12 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
         type=bpy.types.Collection,
     )
 
+    separatemodel: bpy.props.PointerProperty(
+        name='$Models',
+        description='Visible meshes, each mesh becomes $model in the QC; for lightmapping',
+        type=bpy.types.Collection,
+    )
+
     stacking: bpy.props.PointerProperty(
         name='Stacking',
         description='Visible meshes drawn in the specified order',

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -47,6 +47,7 @@ class Model:
         self.collision = model.collision
         self.bodygroups = model.bodygroups
         self.stacking = model.stacking
+        self.separatemodel = model.separatemodel
 
         self.surface = model.surface
         self.glass = model.glass
@@ -98,6 +99,14 @@ class Model:
                 objects = self.get_all_objects(collection)
                 path = self.get_body_path(collection)
                 self.export_mesh(self.armature, objects, path)
+
+        if self.separatemodel:
+            for separatemodel in self.separatemodel.children:
+                for collection in separatemodel.children:
+                    objects = self.get_all_objects(collection)
+                    path = self.get_body_path(collection)
+                    self.export_mesh(self.armature, objects, path)
+
 
     def export_anim(self, armature, action, path):
         self.export_smd(armature, [], action, path)
@@ -247,6 +256,15 @@ class Model:
                 qc.write('\n')
                 name = common.clean_filename(collection.name)
                 qc.write(f'$model "{name}" "{name}.{self.mesh_type}"')
+                qc.write('\n')
+        
+        if self.separatemodel:
+            for separatemodel in self.separatemodel.children:
+                qc.write('\n')
+                bodygroup_name = common.clean_filename(separatemodel.name)
+                for collection in separatemodel.children:
+                    name = common.clean_filename(collection.name)
+                    qc.write(f'$model "{bodygroup_name}" "{name}.{self.mesh_type}"')
                 qc.write('\n')
 
         if not self.sequence_items:

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -73,6 +73,7 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
                 col.prop(model, 'collision')
                 col.prop(model, 'bodygroups')
                 col.prop(model, 'stacking')
+                col.prop(model, 'separatemodel')
 
         elif model and sourceops.panel == 'MODEL_OPTIONS':
             box = layout.box()


### PR DESCRIPTION
Added the ability to have multiple $model in the QC for the purposes of lightmapping static meshes in Hammer.
Also fixed the blockage that prevented bodygroups from happening in static props.