### PR TITLE
Calculate texture scale and offset for brushes.

### DIFF
--- a/addon/ops/export_vmf.py
+++ b/addon/ops/export_vmf.py
@@ -52,9 +52,14 @@ class SOURCEOPS_OT_ExportVMF(bpy.types.Operator):
         geometry_scale = props.geometry_scale
         texture_scale = props.texture_scale
         lightmap_scale = props.lightmap_scale
+        allow_skewed_textures = props.allow_skewed_textures
         align_to_grid = props.align_to_grid
 
-        settings = Settings(brush_objects, disp_objects, geometry_scale, texture_scale, lightmap_scale, align_to_grid)
+        settings = Settings(
+            brush_objects, disp_objects,
+            geometry_scale, texture_scale, lightmap_scale,
+            allow_skewed_textures, align_to_grid
+        )
         vmf = VMF(settings)
         vmf.export(path)
 

--- a/addon/ops/export_vmf.py
+++ b/addon/ops/export_vmf.py
@@ -56,9 +56,13 @@ class SOURCEOPS_OT_ExportVMF(bpy.types.Operator):
         align_to_grid = props.align_to_grid
 
         settings = Settings(
-            brush_objects, disp_objects,
-            geometry_scale, texture_scale, lightmap_scale,
-            allow_skewed_textures, align_to_grid
+            brush_objects,
+            disp_objects,
+            geometry_scale,
+            texture_scale,
+            lightmap_scale,
+            allow_skewed_textures,
+            align_to_grid,
         )
         vmf = VMF(settings)
         vmf.export(path)

--- a/addon/props/map_props.py
+++ b/addon/props/map_props.py
@@ -31,7 +31,7 @@ class SOURCEOPS_MapProps(bpy.types.PropertyGroup):
     texture_scale: bpy.props.FloatProperty(
         name='Texture Scale',
         description='Size of one texel in hammer units',
-        default=0.5,
+        default=1.0,
         min=0,
         max=64,
         step=1,
@@ -44,6 +44,12 @@ class SOURCEOPS_MapProps(bpy.types.PropertyGroup):
         default=32,
         min=1,
         max=16384,
+    )
+
+    allow_skewed_textures: bpy.props.BoolProperty(
+        name='Allow Skewed Textures',
+        description='Allow non-perpendicular UV axes. Works in Hammer as long as faces are not skewed themselves',
+        default=False,
     )
 
     align_to_grid: bpy.props.BoolProperty(

--- a/addon/types/map_export/brush.py
+++ b/addon/types/map_export/brush.py
@@ -41,7 +41,7 @@ def sort_into_parts(bm: bmesh.types.BMesh):
 
 
 def get_texture_size(obj: bpy.types.Object, face: bmesh.types.BMFace):
-    for face.material_index in range(len(obj.material_slots)):
+    if face.material_index in range(len(obj.material_slots)):
         face_material = obj.material_slots[face.material_index].material
         if face_material and face_material.use_nodes:
             for mat_node in face_material.node_tree.nodes:

--- a/addon/types/map_export/brush.py
+++ b/addon/types/map_export/brush.py
@@ -41,17 +41,13 @@ def sort_into_parts(bm: bmesh.types.BMesh):
 
 
 def get_texture_size(obj: bpy.types.Object, face: bmesh.types.BMFace):
-    texture_side_length = -1
-
-    if face.material_index < len(obj.material_slots):
+    for face.material_index in range(len(obj.material_slots)):
         face_material = obj.material_slots[face.material_index].material
         if face_material and face_material.use_nodes:
             for mat_node in face_material.node_tree.nodes:
                 if mat_node.type == 'TEX_IMAGE':
-                    texture_side_length = mat_node.image.size[0]
-                    break
-
-    return texture_side_length
+                    return mat_node.image.size[0]
+    return -1
 
 
 def calc_uv_axes(settings: typing.Any, obj: bpy.types.Object, bm: bmesh.types.BMesh, face: bmesh.types.BMFace):

--- a/addon/types/map_export/brush.py
+++ b/addon/types/map_export/brush.py
@@ -82,7 +82,7 @@ def calc_uv_axes(settings: typing.Any, obj: bpy.types.Object, bm: bmesh.types.BM
     side_v = (p3 - p1) * uv_side_a.x - (p2 - p1) * uv_side_b.x
     determinant = uv_side_a.x * uv_side_b.y - uv_side_b.x * uv_side_a.y
 
-    epsilon = 0.0000001
+    epsilon = 0.0001
 
     if abs(determinant) > epsilon:
         tangent = tangent / determinant

--- a/addon/types/map_export/brush.py
+++ b/addon/types/map_export/brush.py
@@ -40,7 +40,21 @@ def sort_into_parts(bm: bmesh.types.BMesh):
     return parts
 
 
-def calc_uv_axes(settings: typing.Any, bm: bmesh.types.BMesh, face: bmesh.types.BMFace):
+def get_texture_size(obj: bpy.types.Object, face: bmesh.types.BMFace):
+    texture_side_length = -1
+
+    if face.material_index < len(obj.material_slots):
+        face_material = obj.material_slots[face.material_index].material
+        if face_material and face_material.use_nodes:
+            for mat_node in face_material.node_tree.nodes:
+                if mat_node.type == 'TEX_IMAGE':
+                    texture_side_length = mat_node.image.size[0]
+                    break
+
+    return texture_side_length
+
+
+def calc_uv_axes(settings: typing.Any, obj: bpy.types.Object, bm: bmesh.types.BMesh, face: bmesh.types.BMFace):
     points = [loop.vert.co.copy() for loop in face.loops[0:3]]
 
     u_vals = []
@@ -52,7 +66,7 @@ def calc_uv_axes(settings: typing.Any, bm: bmesh.types.BMesh, face: bmesh.types.
         for loop in face.loops[0:3]:
             uv = loop[uv_layer].uv
             u_vals.append(uv[0])
-            v_vals.append(uv[1])
+            v_vals.append(1 - uv[1])
 
     else:
         u_vals = [0, 0, 1]
@@ -62,16 +76,54 @@ def calc_uv_axes(settings: typing.Any, bm: bmesh.types.BMesh, face: bmesh.types.
     u1, u2, u3 = u_vals
     v1, v2, v3 = v_vals
 
-    tangent = -1 * ((p2 - p1) * (v3 - v1) - (p3 - p1) * (v2 - v1))
-    bitangent = mathutils.Quaternion(face.normal, math.radians(90)) @ tangent
+    uv_side_a = mathutils.Vector((u2 - u1, v2 - v1))
+    uv_side_b = mathutils.Vector((u3 - u1, v3 - v1))
+    tangent = (p2 - p1) * uv_side_b.y - (p3 - p1) * uv_side_a.y
+    side_v = (p3 - p1) * uv_side_a.x - (p2 - p1) * uv_side_b.x
+    determinant = uv_side_a.x * uv_side_b.y - uv_side_b.x * uv_side_a.y
 
-    # TODO: Calculate scale and offset
+    epsilon = 0.0000001
+
+    if abs(determinant) > epsilon:
+        tangent = tangent / determinant
+        side_v = side_v / determinant
+
+    if not settings.allow_skewed_textures:
+        bitangent = mathutils.Quaternion(face.normal, math.radians(90)) @ tangent
+        bitangent.normalize()
+        bitangent = bitangent * side_v.dot(bitangent)
+    else:
+        bitangent = side_v
+
+    # Scale
+    texture_side_length = get_texture_size(obj, face)
+    if texture_side_length > 0:
+        u_scale = tangent.magnitude / texture_side_length
+        v_scale = bitangent.magnitude / texture_side_length
+    else:
+        u_scale = 1
+        v_scale = 1
+
+    # Offset
+    tangent_space_transform = mathutils.Matrix((
+        [tangent.x, bitangent.x, face.normal.x],
+        [tangent.y, bitangent.y, face.normal.y],
+        [tangent.z, bitangent.z, face.normal.z]
+    ))
+    if texture_side_length > 0 and abs(tangent_space_transform.determinant()) > epsilon:
+        tangent_space_transform.invert()
+        t1 = tangent_space_transform @ p1
+        u_offset = (1 - (t1.x - u1) * texture_side_length) % texture_side_length
+        v_offset = (1 - (t1.y - v1) * texture_side_length) % texture_side_length
+    else:
+        u_offset = 0
+        v_offset = 0
 
     tangent.normalize()
     bitangent.normalize()
 
-    u_axis = f'[{tangent[0]} {tangent[1]} {tangent[2]} 0] {settings.texture_scale}'
-    v_axis = f'[{bitangent[0]} {bitangent[1]} {bitangent[2]} 0] {settings.texture_scale}'
+    u_axis = f'[{tangent[0]} {tangent[1]} {tangent[2]} {u_offset}] {u_scale * settings.texture_scale}'
+    v_axis = f'[{bitangent[0]} {bitangent[1]} {bitangent[2]} {v_offset}] {v_scale * settings.texture_scale}'
 
     return u_axis, v_axis
 
@@ -111,7 +163,7 @@ def convert_object(settings: typing.Any, obj: bpy.types.Object):
 
                 side.plane.append(vertex)
 
-            u_axis, v_axis = calc_uv_axes(settings, bm, face)
+            u_axis, v_axis = calc_uv_axes(settings, obj, bm, face)
             side.uaxis = pyvmf.Convert.string_to_uvaxis(u_axis)
             side.vaxis = pyvmf.Convert.string_to_uvaxis(v_axis)
 

--- a/addon/types/map_export/vmf.py
+++ b/addon/types/map_export/vmf.py
@@ -9,9 +9,14 @@ from . import displacement
 
 class Settings:
     def __init__(
-            self, brush_objects, disp_objects,
-            geometry_scale, texture_scale, lightmap_scale,
-            allow_skewed_textures, align_to_grid
+            self,
+            brush_objects,
+            disp_objects,
+            geometry_scale,
+            texture_scale,
+            lightmap_scale,
+            allow_skewed_textures,
+            align_to_grid,
     ):
         self.brush_objects = brush_objects
         self.disp_objects = disp_objects

--- a/addon/types/map_export/vmf.py
+++ b/addon/types/map_export/vmf.py
@@ -8,12 +8,17 @@ from . import displacement
 
 
 class Settings:
-    def __init__(self, brush_objects, disp_objects, geometry_scale, texture_scale, lightmap_scale, align_to_grid):
+    def __init__(
+            self, brush_objects, disp_objects,
+            geometry_scale, texture_scale, lightmap_scale,
+            allow_skewed_textures, align_to_grid
+    ):
         self.brush_objects = brush_objects
         self.disp_objects = disp_objects
         self.geometry_scale = geometry_scale
         self.texture_scale = texture_scale
         self.lightmap_scale = lightmap_scale
+        self.allow_skewed_textures = allow_skewed_textures
         self.align_to_grid = align_to_grid
 
 

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -249,6 +249,7 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
                 col.prop(map_props, 'geometry_scale')
                 col.prop(map_props, 'texture_scale')
                 col.prop(map_props, 'lightmap_scale')
+                col.prop(map_props, 'allow_skewed_textures')
                 col.prop(map_props, 'align_to_grid')
 
             box = layout.box()


### PR DESCRIPTION
- Map face vertex UVs to VMF UV axes with shift and scale for brushes. Shift and scale are based on texture image size, so use a material with only one image texture to get the right mapping.
- Add an "Allow Skewed Textures" option in the map export panel to keep non-perpendicular UV axes intact, otherwise it will modify the V axis to make them orthogonal.