### PR TITLE
Export performance

### DIFF
--- a/addon/ops/export_auto.py
+++ b/addon/ops/export_auto.py
@@ -69,13 +69,11 @@ class SOURCEOPS_OT_ExportAuto(bpy.types.Operator):
 
             for source_model in source_models:
                 error = self.export(source_model)
-                print(f'Exported files in {round(time.time() - start, 1)} seconds')
-
                 if error:
                     self.report({'ERROR'}, error)
                     return {'CANCELLED'}
 
-            threads = [Thread(target=self.compile, args=[m], daemon=True) for m in source_models] 
+            threads = [Thread(target=self.compile, args=[m], daemon=True) for m in source_models]
             self._lock = Lock()
             self._results = []
 
@@ -87,7 +85,7 @@ class SOURCEOPS_OT_ExportAuto(bpy.types.Operator):
 
             for error in self._results:
                 self.report({'ERROR'}, error)
-                
+
             if self._results:
                 return {'CANCELLED'}
 
@@ -103,8 +101,6 @@ class SOURCEOPS_OT_ExportAuto(bpy.types.Operator):
                 self.report({'ERROR'}, error)
                 return {'CANCELLED'}
 
-            print(f'Exported files in {round(time.time() - start, 1)} seconds')
-
             error = self.compile(source_model)
             if error:
                 self.report({'ERROR'}, error)
@@ -118,7 +114,7 @@ class SOURCEOPS_OT_ExportAuto(bpy.types.Operator):
             error = source_model.export_meshes()
             if error:
                 return error
-        
+
         if not self.ctrl or self.generate_qc:
             error = source_model.generate_qc()
             if error:

--- a/addon/ops/export_auto.py
+++ b/addon/ops/export_auto.py
@@ -1,4 +1,5 @@
 import bpy
+import time
 from threading import Lock, Thread
 from .. import utils
 from .. types . model_export . model import Model
@@ -61,11 +62,14 @@ class SOURCEOPS_OT_ExportAuto(bpy.types.Operator):
         game = utils.common.get_game(prefs)
         sourceops = utils.common.get_globals(context)
 
+        start = time.time()
+
         if (not self.ctrl and self.shift) or (self.ctrl and self.all_models):
             source_models = [Model(game, model) for model in sourceops.model_items]
 
             for source_model in source_models:
                 error = self.export(source_model)
+                print(f'Exported files in {round(time.time() - start, 1)} seconds')
 
                 if error:
                     self.report({'ERROR'}, error)
@@ -87,21 +91,26 @@ class SOURCEOPS_OT_ExportAuto(bpy.types.Operator):
             if self._results:
                 return {'CANCELLED'}
 
-            self.report({'INFO'}, 'Exported all models in the scene')
+            self.report({'INFO'}, f'Exported all models in the scene in {round(time.time() - start, 1)} seconds')
             return {'FINISHED'}
 
         else:
             model = utils.common.get_model(sourceops)
-
             source_model = Model(game, model)
-            error = self.export(source_model)
-            error = self.compile(source_model)
 
+            error = self.export(source_model)
             if error:
                 self.report({'ERROR'}, error)
                 return {'CANCELLED'}
 
-            self.report({'INFO'}, f'Exported {model.name}')
+            print(f'Exported files in {round(time.time() - start, 1)} seconds')
+
+            error = self.compile(source_model)
+            if error:
+                self.report({'ERROR'}, error)
+                return {'CANCELLED'}
+
+            self.report({'INFO'}, f'Exported {model.name} in {round(time.time() - start, 1)} seconds')
             return {'FINISHED'}
 
     def export(self, source_model: Model):

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -1,4 +1,5 @@
 import bpy
+import time
 import subprocess
 import os
 from math import degrees
@@ -113,25 +114,28 @@ class Model:
     def export_smd(self, armature, objects, action, path):
         try:
             smd_file = path.open('w')
-            print(f'Exporting: {path}')
-
         except:
             self.report(f'Failed to export: {path}', exception=True)
-
         else:
+            start = time.time()
+
             smd = SMD(self.prepend_armature, self.ignore_transforms)
             smd.from_blender(armature, objects, action)
 
             smd_file.write(smd.to_string())
             smd_file.close()
 
-    def export_fbx(self, armature, objects, path):
-        try:
-            print(f'Exporting: {path}')
-            export_fbx(path, armature, objects, self.prepend_armature, self.ignore_transforms)
+            print(f'Exported: {path} in {round(time.time() - start, 1)} seconds')
 
+    def export_fbx(self, armature, objects, path):
+        start = time.time()
+
+        try:
+            export_fbx(path, armature, objects, self.prepend_armature, self.ignore_transforms)
         except:
             self.report(f'Failed to export: {path}', exception=True)
+        else:
+            print(f'Exported: {path} in {round(time.time() - start, 1)} seconds')
 
     def get_all_objects(self, collection):
         return common.remove_duplicates(collection.all_objects) if collection else []


### PR DESCRIPTION
If you export all models at once the exporting is split into two steps. First exporting all files, then compiling them on separate threads. This **greatly** improves the performance!

Compile time now shows within the compile complete message.