### PR TITLE
Add functionality for $renamematerial and allow attaching particles

### DIFF
--- a/addon/ops/list_operator.py
+++ b/addon/ops/list_operator.py
@@ -41,6 +41,7 @@ class SOURCEOPS_OT_ListOperator(bpy.types.Operator):
             ('SEQUENCES', 'Sequences', 'Operate on sequences'),
             ('EVENTS', 'Events', 'Operate on events'),
             ('ATTACHMENTS', 'Attachments', 'Operate on attachments'),
+            ('PARTICLES', 'Particles', 'Operate on particles'),
             ('MAPS', 'Maps', 'Operate on maps'),
         ],
     )
@@ -102,6 +103,7 @@ class SOURCEOPS_OT_ListOperator(bpy.types.Operator):
             'SEQUENCES': (model, 'sequence_items', 'sequence_index'),
             'EVENTS': (sequence, 'event_items', 'event_index'),
             'ATTACHMENTS': (model, 'attachment_items', 'attachment_index'),
+            'PARTICLES': (model, 'particle_items', 'particle_index'),
             'MAPS': (sourceops, 'map_items', 'map_index'),
         }
 

--- a/addon/props/__init__.py
+++ b/addon/props/__init__.py
@@ -1,6 +1,7 @@
 import bpy
 from . map_props import SOURCEOPS_MapProps
 from . attachment_props import SOURCEOPS_AttachmentProps
+from . particle_props import SOURCEOPS_ParticleProps
 from . event_props import SOURCEOPS_EventProps
 from . sequence_props import SOURCEOPS_SequenceProps
 from . skin_props import SOURCEOPS_SkinProps
@@ -14,6 +15,7 @@ from . addon_prefs import SOURCEOPS_AddonPrefs
 def register():
     bpy.utils.register_class(SOURCEOPS_MapProps)
     bpy.utils.register_class(SOURCEOPS_AttachmentProps)
+    bpy.utils.register_class(SOURCEOPS_ParticleProps)
     bpy.utils.register_class(SOURCEOPS_EventProps)
     bpy.utils.register_class(SOURCEOPS_SequenceProps)
     bpy.utils.register_class(SOURCEOPS_SkinProps)
@@ -36,4 +38,5 @@ def unregister():
     bpy.utils.unregister_class(SOURCEOPS_SequenceProps)
     bpy.utils.unregister_class(SOURCEOPS_EventProps)
     bpy.utils.unregister_class(SOURCEOPS_AttachmentProps)
+    bpy.utils.unregister_class(SOURCEOPS_ParticleProps)
     bpy.utils.unregister_class(SOURCEOPS_MapProps)

--- a/addon/props/global_props.py
+++ b/addon/props/global_props.py
@@ -33,8 +33,9 @@ class SOURCEOPS_GlobalProps(bpy.types.PropertyGroup):
             ('SEQUENCES', 'Sequences', 'Display the sequences panel', 'SEQUENCE', 5),
             ('EVENTS', 'Events', 'Display the events panel', 'ACTION', 6),
             ('ATTACHMENTS', 'Attachments', 'Display the attachments panel', 'BONE_DATA', 7),
-            ('MAPS', 'Maps', 'Display the maps panel', 'MOD_BUILD', 8),
-            ('SIMULATION', 'Simulation', 'Display the simulation panel', 'PHYSICS', 9),
-            ('MISC', 'Misc', 'Display the misc panel', 'MONKEY', 10),
+            ('PARTICLES', 'Particles', 'Display the particles panel', 'PARTICLES', 8),
+            ('MAPS', 'Maps', 'Display the maps panel', 'MOD_BUILD', 9),
+            ('SIMULATION', 'Simulation', 'Display the simulation panel', 'PHYSICS', 10),
+            ('MISC', 'Misc', 'Display the misc panel', 'MONKEY', 11),
         ],
     )

--- a/addon/props/model_props.py
+++ b/addon/props/model_props.py
@@ -3,6 +3,7 @@ from . material_folder_props import SOURCEOPS_MaterialFolderProps
 from . skin_props import SOURCEOPS_SkinProps
 from . sequence_props import SOURCEOPS_SequenceProps
 from . attachment_props import SOURCEOPS_AttachmentProps
+from . particle_props import SOURCEOPS_ParticleProps
 from . surface_props import SOURCEOPS_SurfaceProps
 
 
@@ -19,10 +20,19 @@ class SOURCEOPS_ModelProps(bpy.types.PropertyGroup):
     attachment_items: bpy.props.CollectionProperty(type=SOURCEOPS_AttachmentProps)
     attachment_index: bpy.props.IntProperty(default=0, name='Ctrl click to rename')
 
+    particle_items: bpy.props.CollectionProperty(type=SOURCEOPS_ParticleProps)
+    particle_index: bpy.props.IntProperty(default=0, name='Ctrl click to rename')
+
     name: bpy.props.StringProperty(
         name='Name',
         description='Your model\'s path, eg example/model',
         default='example/model',
+    )
+
+    rename_material: bpy.props.StringProperty(
+        name='Rename Material',
+        description='Rename the first material currently on your model when exporting',
+        default='',
     )
 
     def poll_armature(self, object):

--- a/addon/props/particle_props.py
+++ b/addon/props/particle_props.py
@@ -1,0 +1,28 @@
+import bpy
+
+SOURCEOPS_ParticleAttachProps = [
+    ('start_at_origin', 'start_at_origin', ''),
+    ('start_at_attachment', 'start_at_attachment', ''),
+    ('follow_origin', 'follow_origin', ''),
+    ('follow_attachment', 'follow_attachment', ''),
+]
+
+class SOURCEOPS_ParticleProps(bpy.types.PropertyGroup):
+    name: bpy.props.StringProperty(
+        name='Name',
+        description='The name of a particle system. NOT the name of a .pcf file!',
+        default='Particle',
+    )
+
+    attachment_type: bpy.props.EnumProperty(
+        name='Attachment Type',
+        description='The method of attaching the particle to the prop',
+        items=SOURCEOPS_ParticleAttachProps,
+        default='start_at_origin',
+    )
+
+    attachment_point: bpy.props.StringProperty(
+        name='Attachment Point',
+        description='The attachment point at which the particle system should spawn, if applicable',
+        default='',
+    )

--- a/addon/types/model_export/model.py
+++ b/addon/types/model_export/model.py
@@ -46,6 +46,7 @@ class Model:
         self.skin_items = model.skin_items
         self.sequence_items = model.sequence_items
         self.attachment_items = model.attachment_items
+        self.particle_items = model.particle_items
 
         self.armature = model.armature
         self.reference = model.reference
@@ -53,6 +54,7 @@ class Model:
         self.bodygroups = model.bodygroups
         self.stacking = model.stacking
 
+        self.rename_material = model.rename_material
         self.surface = model.surface
         self.glass = model.glass
         self.static = model.static
@@ -230,6 +232,11 @@ class Model:
             qc.write(f'$body "{name}" "{name}.{self.mesh_type}"')
             qc.write('\n')
 
+        if not self.rename_material == '':
+            qc.write('\n')
+            qc.write(f'$renamematerial {self.rename_material}')
+            qc.write('\n')
+
         if self.collision:
             qc.write('\n')
             name = common.clean_filename(self.collision.name)
@@ -313,7 +320,34 @@ class Model:
             qc.write('\n')
             qc.write('}')
             qc.write('\n')
-
+        
+        if(len(self.particle_items) > 0):
+            qc.write('\n')      
+            qc.write('$keyvalues')
+            qc.write('\n')
+            qc.write('{')
+            qc.write('\n')
+            qc.write('    particles')
+            qc.write('\n')
+            qc.write('    {')
+            
+            for index, particle in enumerate(self.particle_items):
+                qc.write('\n')
+                qc.write(f'        "effect{index}"')
+                qc.write('\n        {\n')
+                qc.write(f'            "name" "{particle.name}"')
+                qc.write('\n')
+                qc.write(f'            "attachment_type" "{particle.attachment_type}"')
+                qc.write('\n')
+                if(particle.attachment_point):
+                    qc.write(f'            "attachment_point" "{particle.attachment_point}"')
+                    qc.write('\n')
+                qc.write('        }\n')
+            
+            qc.write('    }')
+            qc.write('\n')
+            qc.write('}')
+        
         qc.close()
 
     def compile_qc(self):

--- a/addon/ui/__init__.py
+++ b/addon/ui/__init__.py
@@ -6,6 +6,7 @@ from . lists import SOURCEOPS_UL_SkinList
 from . lists import SOURCEOPS_UL_SequenceList
 from . lists import SOURCEOPS_UL_EventList
 from . lists import SOURCEOPS_UL_AttachmentList
+from . lists import SOURCEOPS_UL_ParticleList
 from . lists import SOURCEOPS_UL_MapList
 from . panels import SOURCEOPS_PT_MainPanel
 
@@ -18,6 +19,7 @@ def register():
     bpy.utils.register_class(SOURCEOPS_UL_SequenceList)
     bpy.utils.register_class(SOURCEOPS_UL_EventList)
     bpy.utils.register_class(SOURCEOPS_UL_AttachmentList)
+    bpy.utils.register_class(SOURCEOPS_UL_ParticleList)
     bpy.utils.register_class(SOURCEOPS_UL_MapList)
     bpy.utils.register_class(SOURCEOPS_PT_MainPanel)
 
@@ -26,6 +28,7 @@ def unregister():
     bpy.utils.unregister_class(SOURCEOPS_PT_MainPanel)
     bpy.utils.unregister_class(SOURCEOPS_UL_MapList)
     bpy.utils.unregister_class(SOURCEOPS_UL_AttachmentList)
+    bpy.utils.unregister_class(SOURCEOPS_UL_ParticleList)
     bpy.utils.unregister_class(SOURCEOPS_UL_EventList)
     bpy.utils.unregister_class(SOURCEOPS_UL_SequenceList)
     bpy.utils.unregister_class(SOURCEOPS_UL_SkinList)

--- a/addon/ui/lists.py
+++ b/addon/ui/lists.py
@@ -50,6 +50,13 @@ class SOURCEOPS_UL_AttachmentList(bpy.types.UIList):
         layout.prop(item, 'name', text='', emboss=False, translate=False)
 
 
+class SOURCEOPS_UL_ParticleList(bpy.types.UIList):
+    bl_idname = 'SOURCEOPS_UL_ParticleList'
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
+        layout.prop(item, 'name', text='', emboss=False, translate=False)
+
+
 class SOURCEOPS_UL_MapList(bpy.types.UIList):
     bl_idname = 'SOURCEOPS_UL_MapList'
 

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -22,6 +22,7 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
         sequence = common.get_sequence(model)
         event = common.get_event(sequence)
         attachment = common.get_attachment(model)
+        particle = common.get_particle(model)
         map_props = common.get_map(sourceops)
 
         if sourceops:
@@ -84,6 +85,7 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
             col.prop(model, 'surface')
             col.prop(model, 'glass')
             col.prop(model, 'static')
+            col.prop(model, 'rename_material')
             row = col.row()
             row.enabled = model.static
             row.prop(model, 'static_prop_combine')
@@ -194,6 +196,23 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
                 col.prop(event, 'frame')
                 col.prop(event, 'value')
 
+        elif model and sourceops.panel == 'PARTICLES':
+            box = layout.box()
+            row = box.row()
+            row.alignment = 'CENTER'
+            row.label(text='Particles')
+            
+            row = box.row()
+            row.template_list('SOURCEOPS_UL_ParticleList', '', model, 'particle_items', model, 'particle_index', rows=5)
+            col = row.column(align=True)
+            self.draw_list_buttons(col, 'PARTICLES')
+
+            if particle:
+                col = common.split_column(box)
+                col.prop(particle, 'name')
+                col.prop(particle, 'attachment_type')
+                col.prop(particle, 'attachment_point')
+
         elif model and sourceops.panel == 'ATTACHMENTS':
             box = layout.box()
             row = box.row()
@@ -218,7 +237,7 @@ class SOURCEOPS_PT_MainPanel(bpy.types.Panel):
                 col.prop(attachment, 'absolute')
                 col.prop(attachment, 'rigid')
 
-        if sourceops.panel in {'GAMES', 'MODELS', 'MODEL_OPTIONS', 'TEXTURES', 'SEQUENCES', 'EVENTS', 'ATTACHMENTS'}:
+        if sourceops.panel in {'GAMES', 'MODELS', 'MODEL_OPTIONS', 'TEXTURES', 'SEQUENCES', 'EVENTS', 'ATTACHMENTS', 'PARTICLES'}:
             box = layout.box()
             row = box.row()
             row.scale_x = row.scale_y = 1.5

--- a/addon/utils/common.py
+++ b/addon/utils/common.py
@@ -72,6 +72,11 @@ def get_attachment(model):
     except:
         return None
 
+def get_particle(model):
+    try:
+        return model.particle_items[model.particle_index]
+    except:
+        return None
 
 def get_map(sourceops):
     try:


### PR DESCRIPTION
This PR adds support for $renamematerial in the models tab, and a new particles tab for attaching particles without the need for manually editing the qc.