### PR TITLE
Use mesh UVs when exporting displacements

### DIFF
--- a/addon/types/map_export/brush.py
+++ b/addon/types/map_export/brush.py
@@ -1,9 +1,9 @@
 import bpy
 import bmesh
 import mathutils
-import math
 import typing
 from .. pyvmf import pyvmf
+from ... utils import map_export
 
 
 def sort_into_parts(bm: bmesh.types.BMesh):
@@ -40,92 +40,6 @@ def sort_into_parts(bm: bmesh.types.BMesh):
     return parts
 
 
-def get_texture_size(obj: bpy.types.Object, face: bmesh.types.BMFace):
-    if face.material_index in range(len(obj.material_slots)):
-        face_material = obj.material_slots[face.material_index].material
-
-        if face_material and face_material.use_nodes:
-            for mat_node in face_material.node_tree.nodes:
-                if mat_node.type == 'TEX_IMAGE':
-                    return mat_node.image.size[0]
-
-    return -1
-
-
-def calc_uv_axes(settings: typing.Any, obj: bpy.types.Object, bm: bmesh.types.BMesh, face: bmesh.types.BMFace):
-    points = [loop.vert.co.copy() for loop in face.loops[0:3]]
-
-    u_vals = []
-    v_vals = []
-
-    if len(bm.loops.layers.uv) > 0:
-        uv_layer = bm.loops.layers.uv.verify()
-
-        for loop in face.loops[0:3]:
-            uv = loop[uv_layer].uv
-            u_vals.append(uv[0])
-            v_vals.append(1 - uv[1])
-
-    else:
-        u_vals = [0, 0, 1]
-        v_vals = [0, 1, 1]
-
-    p1, p2, p3 = points
-    u1, u2, u3 = u_vals
-    v1, v2, v3 = v_vals
-
-    uv_side_a = mathutils.Vector((u2 - u1, v2 - v1))
-    uv_side_b = mathutils.Vector((u3 - u1, v3 - v1))
-    tangent = (p2 - p1) * uv_side_b.y - (p3 - p1) * uv_side_a.y
-    side_v = (p3 - p1) * uv_side_a.x - (p2 - p1) * uv_side_b.x
-    determinant = uv_side_a.x * uv_side_b.y - uv_side_b.x * uv_side_a.y
-
-    epsilon = 0.0001
-
-    if abs(determinant) > epsilon:
-        tangent = tangent / determinant
-        side_v = side_v / determinant
-
-    if not settings.allow_skewed_textures:
-        bitangent = mathutils.Quaternion(face.normal, math.radians(90)) @ tangent
-        bitangent.normalize()
-        bitangent = bitangent * side_v.dot(bitangent)
-    else:
-        bitangent = side_v
-
-    # Scale
-    texture_side_length = get_texture_size(obj, face)
-    if texture_side_length > 0:
-        u_scale = tangent.magnitude / texture_side_length
-        v_scale = bitangent.magnitude / texture_side_length
-    else:
-        u_scale = 1
-        v_scale = 1
-
-    # Offset
-    tangent_space_transform = mathutils.Matrix((
-        [tangent.x, bitangent.x, face.normal.x],
-        [tangent.y, bitangent.y, face.normal.y],
-        [tangent.z, bitangent.z, face.normal.z]
-    ))
-    if texture_side_length > 0 and abs(tangent_space_transform.determinant()) > epsilon:
-        tangent_space_transform.invert()
-        t1 = tangent_space_transform @ p1
-        u_offset = (1 - (t1.x - u1) * texture_side_length) % texture_side_length
-        v_offset = (1 - (t1.y - v1) * texture_side_length) % texture_side_length
-    else:
-        u_offset = 0
-        v_offset = 0
-
-    tangent.normalize()
-    bitangent.normalize()
-
-    u_axis = f'[{tangent[0]} {tangent[1]} {tangent[2]} {u_offset}] {u_scale * settings.texture_scale}'
-    v_axis = f'[{bitangent[0]} {bitangent[1]} {bitangent[2]} {v_offset}] {v_scale * settings.texture_scale}'
-
-    return u_axis, v_axis
-
-
 def convert_object(settings: typing.Any, obj: bpy.types.Object):
     solids = []
 
@@ -153,6 +67,8 @@ def convert_object(settings: typing.Any, obj: bpy.types.Object):
 
             side.plane.clear()
 
+            points = []
+
             for vert in face.verts[0:3]:
                 vertex = pyvmf.Vertex(*vert.co)
 
@@ -160,8 +76,28 @@ def convert_object(settings: typing.Any, obj: bpy.types.Object):
                     vertex.align_to_grid()
 
                 side.plane.append(vertex)
+                points.append(mathutils.Vector((vertex.x, vertex.y, vertex.z)))
 
-            u_axis, v_axis = calc_uv_axes(settings, obj, bm, face)
+            uvs = []
+
+            if len(bm.loops.layers.uv) > 0:
+                uv_layer = bm.loops.layers.uv.verify()
+
+                for loop in face.loops[0:3]:
+                    uvs.append(loop[uv_layer].uv)
+
+            else:
+                uvs.append(mathutils.Vector((0, 0)))
+                uvs.append(mathutils.Vector((0, 1)))
+                uvs.append(mathutils.Vector((1, 1)))
+
+            p1, p2, p3 = points
+            uv1, uv2, uv3 = uvs
+            texture_size = map_export.get_texture_size(obj, face)
+            texture_scale = settings.texture_scale
+            allow_skewed_textures = settings.allow_skewed_textures
+            u_axis, v_axis = map_export.calc_uv_axes(p1, p2, p3, uv1, uv2, uv3, allow_skewed_textures, texture_size, texture_scale)
+
             side.uaxis = pyvmf.Convert.string_to_uvaxis(u_axis)
             side.vaxis = pyvmf.Convert.string_to_uvaxis(v_axis)
 

--- a/addon/types/map_export/displacement.py
+++ b/addon/types/map_export/displacement.py
@@ -134,8 +134,13 @@ def setup_uv_layers(obj: bpy.types.Object):
     # Copy UV coordinates and remove existing UV layers
     for uv_layer in obj.data.uv_layers[:]:
         if not original_uvs and uv_layer.active_render:
-            original_uvs = [0.0] * 2 * len(uv_layer.uv)
-            uv_layer.uv.foreach_get('vector', original_uvs)
+            if bpy.app.version[0] < 4:
+                original_uvs = [0.0] * 2 * len(uv_layer.data)
+                uv_layer.data.foreach_get('uv', original_uvs)
+
+            else:
+                original_uvs = [0.0] * 2 * len(uv_layer.uv)
+                uv_layer.uv.foreach_get('vector', original_uvs)
 
         obj.data.uv_layers.remove(uv_layer)
 
@@ -145,7 +150,11 @@ def setup_uv_layers(obj: bpy.types.Object):
     # Recreate existing UV layer if necessary
     if original_uvs:
         texture_uv_layer = obj.data.uv_layers.new()
-        texture_uv_layer.uv.foreach_set('vector', original_uvs)
+
+        if bpy.app.version[0] < 4:
+            texture_uv_layer.data.foreach_set('uv', original_uvs)
+        else:
+            texture_uv_layer.uv.foreach_set('vector', original_uvs)
     else:
         texture_uv_layer = None
 

--- a/addon/utils/map_export.py
+++ b/addon/utils/map_export.py
@@ -1,0 +1,75 @@
+import bpy
+import bmesh
+import mathutils
+import math
+
+
+def get_texture_size(obj: bpy.types.Object, face: bmesh.types.BMFace):
+    if face.material_index in range(len(obj.material_slots)):
+        face_material = obj.material_slots[face.material_index].material
+
+        if face_material and face_material.use_nodes:
+            for mat_node in face_material.node_tree.nodes:
+                if mat_node.type == 'TEX_IMAGE':
+                    return mat_node.image.size[0]
+
+    return -1
+
+
+def calc_uv_axes(p1: mathutils.Vector, p2: mathutils.Vector, p3: mathutils.Vector, uv1: mathutils.Vector, uv2: mathutils.Vector, uv3: mathutils.Vector, allow_skewed_textures: bool, texture_size: float, texture_scale: float):
+    '''Calculate U and V axes for brush plane using provided UV coordinates'''
+    
+    normal = mathutils.Vector.cross(p2 - p1, p3 - p1).normalized()
+
+    u1, u2, u3 = uv1[0], uv2[0], uv3[0]
+    v1, v2, v3 = 1.0 - uv1[1], 1.0 - uv2[1], 1.0 - uv3[1]
+
+    uv_side_a = mathutils.Vector((u2 - u1, v2 - v1))
+    uv_side_b = mathutils.Vector((u3 - u1, v3 - v1))
+    tangent = (p2 - p1) * uv_side_b.y - (p3 - p1) * uv_side_a.y
+    side_v = (p3 - p1) * uv_side_a.x - (p2 - p1) * uv_side_b.x
+    determinant = uv_side_a.x * uv_side_b.y - uv_side_b.x * uv_side_a.y
+
+    epsilon = 0.0001
+
+    if abs(determinant) > epsilon:
+        tangent = tangent / determinant
+        side_v = side_v / determinant
+
+    if not allow_skewed_textures:
+        bitangent = mathutils.Quaternion(normal, math.radians(90)) @ tangent
+        bitangent.normalize()
+        bitangent = bitangent * side_v.dot(bitangent)
+    else:
+        bitangent = side_v
+
+    # Scale
+    if texture_size > 0:
+        u_scale = tangent.magnitude / texture_size
+        v_scale = bitangent.magnitude / texture_size
+    else:
+        u_scale = 1
+        v_scale = 1
+
+    # Offset
+    tangent_space_transform = mathutils.Matrix((
+        [tangent.x, bitangent.x, normal.x],
+        [tangent.y, bitangent.y, normal.y],
+        [tangent.z, bitangent.z, normal.z]
+    ))
+    if texture_size > 0 and abs(tangent_space_transform.determinant()) > epsilon:
+        tangent_space_transform.invert()
+        t1 = tangent_space_transform @ p1
+        u_offset = (1 - (t1.x - u1) * texture_size) % texture_size
+        v_offset = (1 - (t1.y - v1) * texture_size) % texture_size
+    else:
+        u_offset = 0
+        v_offset = 0
+
+    tangent.normalize()
+    bitangent.normalize()
+
+    u_axis = f'[{tangent[0]} {tangent[1]} {tangent[2]} {u_offset}] {u_scale * texture_scale}'
+    v_axis = f'[{bitangent[0]} {bitangent[1]} {bitangent[2]} {v_offset}] {v_scale * texture_scale}'
+
+    return u_axis, v_axis


### PR DESCRIPTION
Allows displacements to be exported using the UV coordinates of the original mesh, just like brushes. The previous behavior (auto-generated UVs) is still used when the mesh has no UVs, e.g. the leftmost displacement in this image.
<img width="2449" height="872" alt="Blender/Hammer comparison" src="https://github.com/user-attachments/assets/04f76cc2-65ea-4393-ac5c-5f21946a4cc1" />

`get_texture_size` and `calc_uv_axes` have been moved to a new file as they're now used by displacements and regular brushes alike. The latter has some small changes to account for the fact that it now expects vertex/UV coordinates rather than an object/bmesh/face, but as far as I can tell it should still work the same way for brushes as it used to.